### PR TITLE
acknowledgment: use north american spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Avrohom Hillel Weissman sent in some stuff;
 - added missing questions to parshas Pinchas, Shoftim, Mishpatim, Yisro, Vayikra;
 - added questions for parshas Bereishis that were added to his copy of the book;
-- added acknowledgement;
+- added acknowledgment;
 
 ## [] - 2015-02-01
 - publishing site repository at www.chumashquestions.org.
@@ -53,7 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maven-standard layout and build;
 - moved TODOs to GitHub issues;
 - HTML stylesheet;
-- README.md, Preface 2e, colophon and acknowledgements.
+- README.md, Preface 2e, colophon and acknowledgments.
 
 ## [] - 2014-09-17
 - holiday questions;

--- a/docs/book.html
+++ b/docs/book.html
@@ -33,7 +33,7 @@
 <ul class="sectlevel1">
 <li><a href="#colophon">Colophon</a></li>
 <li><a href="#dedication">Dedication</a></li>
-<li><a href="#acknowledgements">Acknowledgements</a></li>
+<li><a href="#acknowledgments">Acknowledgments</a></li>
 <li><a href="#about-author">Rabbi Dovid Wichnin, 1938-1995</a></li>
 <li><a href="#foreword">Foreword</a></li>
 <li><a href="#introduction">Introduction</a></li>
@@ -143,7 +143,7 @@ Published by the <a href="http://www.opentorah.org">Open Torah Project</a>.</p>
 <div class="paragraph">
 <p>This is a re-publication of Rabbi Wichnin&#8217;s Chumash Questions book, first edition of which, published in 1995, is long since out of print.
 People who made this publication possible are listed in the
-<a href="/html/acknowledgements.html">Acknowledgements</a>.</p>
+<a href="/html/acknowledgments.html">Acknowledgments</a>.</p>
 </div>
 <div class="paragraph">
 <p>Corrections, additions and suggestions are welcome at <a href="mailto:dub@chumashquestions.org">dub@chumashquestions.org</a>.</p>
@@ -187,7 +187,7 @@ The book is licensed under the
 </div>
 </div>
 <div class="sect1">
-<h2 id="acknowledgements"><a class="anchor" href="#acknowledgements"></a><a class="link" href="#acknowledgements">Acknowledgements</a></h2>
+<h2 id="acknowledgments"><a class="anchor" href="#acknowledgments"></a><a class="link" href="#acknowledgments">Acknowledgments</a></h2>
 <div class="sectionbody">
 <h3 id="_second_edition" class="discrete">Second Edition</h3>
 <div class="paragraph">

--- a/docs/book.pdf
+++ b/docs/book.pdf
@@ -4402,7 +4402,7 @@ endobj
 << /Border [0 0 0]
 /A << /Type /Action
 /S /URI
-/URI (/html/acknowledgements.html)
+/URI (/html/acknowledgments.html)
 >>
 /Subtype /Link
 /Rect [66.93 647.24 164.60079 661.52]
@@ -195719,7 +195719,7 @@ endobj
 endobj
 1808 0 obj
 << /Limits [(ach) (amos)]
-/Names [(ach) 1807 0 R (acharei) 869 0 R (acknowledgements) 48 0 R (akdamus) 1809 0 R (akeidah) 1810 0 R (al-hanissim) 1811 0 R (aliyah) 1812 0 R (aliyos) 1813 0 R (am-yisroel) 1815 0 R (amos) 1814 0 R]
+/Names [(ach) 1807 0 R (acharei) 869 0 R (acknowledgments) 48 0 R (akdamus) 1809 0 R (akeidah) 1810 0 R (al-hanissim) 1811 0 R (aliyah) 1812 0 R (aliyos) 1813 0 R (am-yisroel) 1815 0 R (amos) 1814 0 R]
 >>
 endobj
 1809 0 obj
@@ -210047,7 +210047,7 @@ endobj
 endobj
 2265 0 obj
 << /Border [0 0 0]
-/Dest (acknowledgements)
+/Dest (acknowledgments)
 /Subtype /Link
 /Rect [48.24 711.83 145.91079 726.11]
 /Type /Annot
@@ -210055,7 +210055,7 @@ endobj
 endobj
 2266 0 obj
 << /Border [0 0 0]
-/Dest (acknowledgements)
+/Dest (acknowledgments)
 /Subtype /Link
 /Rect [541.1705 711.83 547.04 726.11]
 /Type /Annot

--- a/docs/html/about-author.html
+++ b/docs/html/about-author.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html"><span class="toc-current">Rabbi Dovid Wichnin, 1938-1995</span></a>
 </li>
@@ -93,7 +93,7 @@
 </div>
 </div>
 <div class="paragraph nav-footer">
-<p>← Previous: <a href="acknowledgements.html">Acknowledgements</a> | ↑ Up: <a href="book.html">The Chumash Questions</a> | Next: <a href="foreword.html">Foreword</a> →</p>
+<p>← Previous: <a href="acknowledgments.html">Acknowledgments</a> | ↑ Up: <a href="book.html">The Chumash Questions</a> | Next: <a href="foreword.html">Foreword</a> →</p>
 </div>
 </div>
 <div id="footer">

--- a/docs/html/acharei.html
+++ b/docs/html/acharei.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/acknowledgments.html
+++ b/docs/html/acknowledgments.html
@@ -21,7 +21,7 @@
   gtag('config', 'G-DK8H23BZHM');
 </script>
 </head>
-<body id="acknowledgements" class="book">
+<body id="acknowledgments" class="book">
 <div id="header">
 <h1>The Chumash Questions</h1>
 <div class="details">
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html"><span class="toc-current">Acknowledgements</span></a>
+<li><a href="acknowledgments.html"><span class="toc-current">Acknowledgments</span></a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>
@@ -64,7 +64,7 @@
 </div>
 <div id="content">
 <div class="sect1">
-<h2 id="acknowledgements"><a class="anchor" href="#acknowledgements"></a><a class="link" href="#acknowledgements">Acknowledgements</a></h2>
+<h2 id="acknowledgments"><a class="anchor" href="#acknowledgments"></a><a class="link" href="#acknowledgments">Acknowledgments</a></h2>
 <div class="sectionbody">
 <h3 id="_second_edition" class="discrete">Second Edition</h3>
 <div class="paragraph">

--- a/docs/html/balak.html
+++ b/docs/html/balak.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/bamidbar-index.html
+++ b/docs/html/bamidbar-index.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/bamidbar.html
+++ b/docs/html/bamidbar.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/bechukosai.html
+++ b/docs/html/bechukosai.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/behaaloscha.html
+++ b/docs/html/behaaloscha.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/behar.html
+++ b/docs/html/behar.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/bereishis-index.html
+++ b/docs/html/bereishis-index.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/bereishis.html
+++ b/docs/html/bereishis.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/beshalach.html
+++ b/docs/html/beshalach.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/bo.html
+++ b/docs/html/bo.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/book.html
+++ b/docs/html/book.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>
@@ -72,7 +72,7 @@
 <p><a href="dedication.html">Dedication</a></p>
 </li>
 <li>
-<p><a href="acknowledgements.html">Acknowledgements</a></p>
+<p><a href="acknowledgments.html">Acknowledgments</a></p>
 </li>
 <li>
 <p><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a></p>

--- a/docs/html/chanukah.html
+++ b/docs/html/chanukah.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/chayei-sara.html
+++ b/docs/html/chayei-sara.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/chukas.html
+++ b/docs/html/chukas.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/colophon.html
+++ b/docs/html/colophon.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>
@@ -76,7 +76,7 @@ Published by the <a href="http://www.opentorah.org">Open Torah Project</a>.</p>
 <div class="paragraph">
 <p>This is a re-publication of Rabbi Wichnin&#8217;s Chumash Questions book, first edition of which, published in 1995, is long since out of print.
 People who made this publication possible are listed in the
-<a href="/html/acknowledgements.html">Acknowledgements</a>.</p>
+<a href="/html/acknowledgments.html">Acknowledgments</a>.</p>
 </div>
 <div class="paragraph">
 <p>Corrections, additions and suggestions are welcome at <a href="mailto:dub@chumashquestions.org">dub@chumashquestions.org</a>.</p>

--- a/docs/html/dedication.html
+++ b/docs/html/dedication.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html"><span class="toc-current">Dedication</span></a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>
@@ -72,7 +72,7 @@
 </div>
 </div>
 <div class="paragraph nav-footer">
-<p>← Previous: <a href="colophon.html">Colophon</a> | ↑ Up: <a href="book.html">The Chumash Questions</a> | Next: <a href="acknowledgements.html">Acknowledgements</a> →</p>
+<p>← Previous: <a href="colophon.html">Colophon</a> | ↑ Up: <a href="book.html">The Chumash Questions</a> | Next: <a href="acknowledgments.html">Acknowledgments</a> →</p>
 </div>
 </div>
 <div id="footer">

--- a/docs/html/devarim-index.html
+++ b/docs/html/devarim-index.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/devarim.html
+++ b/docs/html/devarim.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/eikev.html
+++ b/docs/html/eikev.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/emor.html
+++ b/docs/html/emor.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/foreword.html
+++ b/docs/html/foreword.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/glossary.html
+++ b/docs/html/glossary.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/holidays-index.html
+++ b/docs/html/holidays-index.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/introduction.html
+++ b/docs/html/introduction.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/kedoshim.html
+++ b/docs/html/kedoshim.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/ki-savo.html
+++ b/docs/html/ki-savo.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/ki-seitzei.html
+++ b/docs/html/ki-seitzei.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/ki-sissa.html
+++ b/docs/html/ki-sissa.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/korach.html
+++ b/docs/html/korach.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/lech-lecha.html
+++ b/docs/html/lech-lecha.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/masei.html
+++ b/docs/html/masei.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/matos.html
+++ b/docs/html/matos.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/metzorah.html
+++ b/docs/html/metzorah.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/miketz.html
+++ b/docs/html/miketz.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/mishpatim.html
+++ b/docs/html/mishpatim.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/nine-days.html
+++ b/docs/html/nine-days.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/nitzavim.html
+++ b/docs/html/nitzavim.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/noach.html
+++ b/docs/html/noach.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/noso.html
+++ b/docs/html/noso.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/notes.html
+++ b/docs/html/notes.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/pekudei.html
+++ b/docs/html/pekudei.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/pesach.html
+++ b/docs/html/pesach.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/pinchas.html
+++ b/docs/html/pinchas.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/purim.html
+++ b/docs/html/purim.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/re-eh.html
+++ b/docs/html/re-eh.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/rosh-hashonoh.html
+++ b/docs/html/rosh-hashonoh.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/sefiras-ha-omer.html
+++ b/docs/html/sefiras-ha-omer.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/shavuos.html
+++ b/docs/html/shavuos.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/shelach.html
+++ b/docs/html/shelach.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/shemini.html
+++ b/docs/html/shemini.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/shemos-index.html
+++ b/docs/html/shemos-index.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/shemos.html
+++ b/docs/html/shemos.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/shoftim.html
+++ b/docs/html/shoftim.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/sukkos.html
+++ b/docs/html/sukkos.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/tazria.html
+++ b/docs/html/tazria.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/terumah.html
+++ b/docs/html/terumah.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/tetzaveh.html
+++ b/docs/html/tetzaveh.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/tisha-b-av.html
+++ b/docs/html/tisha-b-av.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/toldos.html
+++ b/docs/html/toldos.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/tzav.html
+++ b/docs/html/tzav.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/va-eira.html
+++ b/docs/html/va-eira.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/vayakhel.html
+++ b/docs/html/vayakhel.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/vayechi.html
+++ b/docs/html/vayechi.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/vayeira.html
+++ b/docs/html/vayeira.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/vayeishev.html
+++ b/docs/html/vayeishev.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/vayeitzei.html
+++ b/docs/html/vayeitzei.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/vayigash.html
+++ b/docs/html/vayigash.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/vayikra-index.html
+++ b/docs/html/vayikra-index.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/vayikra.html
+++ b/docs/html/vayikra.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/vayishlach.html
+++ b/docs/html/vayishlach.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/veyeilech.html
+++ b/docs/html/veyeilech.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/vo-eschanan.html
+++ b/docs/html/vo-eschanan.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/yisro.html
+++ b/docs/html/yisro.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/yom-kippur.html
+++ b/docs/html/yom-kippur.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/html/yud-shevat-and-tu-b-shevat.html
+++ b/docs/html/yud-shevat-and-tu-b-shevat.html
@@ -35,7 +35,7 @@
 </li>
 <li><a href="dedication.html">Dedication</a>
 </li>
-<li><a href="acknowledgements.html">Acknowledgements</a>
+<li><a href="acknowledgments.html">Acknowledgments</a>
 </li>
 <li><a href="about-author.html">Rabbi Dovid Wichnin, 1938-1995</a>
 </li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@ Published by the <a href="http://www.opentorah.org">Open Torah Project</a>.</p>
 <div class="paragraph">
 <p>This is a re-publication of Rabbi Wichnin&#8217;s Chumash Questions book, first edition of which, published in 1995, is long since out of print.
 People who made this publication possible are listed in the
-<a href="/html/acknowledgements.html">Acknowledgements</a>.</p>
+<a href="/html/acknowledgments.html">Acknowledgments</a>.</p>
 </div>
 <div class="paragraph">
 <p>Corrections, additions and suggestions are welcome at <a href="mailto:dub@chumashquestions.org">dub@chumashquestions.org</a>.</p>

--- a/src/docs/asciidoc/acknowledgments.adoc
+++ b/src/docs/asciidoc/acknowledgments.adoc
@@ -1,6 +1,6 @@
-[#acknowledgements]
+[#acknowledgments]
 [acknowledgments]
-== Acknowledgements
+== Acknowledgments
 
 [discrete]
 === Second Edition

--- a/src/docs/asciidoc/book.adoc
+++ b/src/docs/asciidoc/book.adoc
@@ -24,7 +24,7 @@ include::{srcDir}/colophon.adoc[]
 
 include::{srcDir}/dedication.adoc[]
 
-include::{srcDir}/acknowledgements.adoc[]
+include::{srcDir}/acknowledgments.adoc[]
 
 include::{srcDir}/about-author.adoc[]
 

--- a/src/docs/asciidoc/colophon.adoc
+++ b/src/docs/asciidoc/colophon.adoc
@@ -5,7 +5,7 @@ Published by the http://www.opentorah.org[Open Torah Project].
 
 This is a re-publication of Rabbi Wichnin's Chumash Questions book, first edition of which, published in 1995, is long since out of print.
 People who made this publication possible are listed in the
-link:/html/acknowledgements.html[Acknowledgements].
+link:/html/acknowledgments.html[Acknowledgments].
 
 Corrections, additions and suggestions are welcome at dub@chumashquestions.org.
 


### PR DESCRIPTION
The result of doing the following on macOS:

```sh
git grep --files-with-matches --ignore-case acknowledgement | LC_ALL=C xargs sed -i '' -e 's/cknowledgement/cknowledgment/g'

find . -iname '*acknowledgement*' -exec bash -c 'mv $0 ${0/cknowledgement/cknowledgment}' {} \;
```

Why? My school teachers cared about this. Because R' Wichnin lived in North America, one might think to use its [preferred spelling](https://grammarist.com/spelling/acknowledgment-acknowledgement/ "https://grammarist.com/spelling/acknowledgment-acknowledgement/"). Both spellings are considered correct though, which makes this change, admittedly, pedantic.